### PR TITLE
Notice: Require sign that license applies to software

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ $(BUILD)/%.md: $(BUILD)/%.form $(BUILD)/%.title $(BUILD)/%.directions $(BUILD)/%
 		< $< | \
 		sed 's/^!!! \(.\+\)$$/***\1***/' | \
 		sed 's!\\/!/!g' | \
-		sed 's!\(https://.\+\).$$!<\1>.!g' | \
+		sed -E 's!(https://[^ ]+)!<\1>!g' | \
 		fmt -u -w64 \
 		> $@
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ $(BUILD)/%.edition: $(BUILD)/%.json | $(JSON)
 	$(JSON) frontMatter.version < $< > $@
 
 $(BUILD)/%.values: $(BUILD)/%.json
-	node -e 'var value = require("./$(BUILD)/$*.json").frontMatter.version; console.log(JSON.stringify({ version: value === "Development Draft" ? "$$version" : value }))' > $@
+	node -e 'var value = require("./$(BUILD)/$*.json").frontMatter.version; console.log(JSON.stringify({ version: value === "Development Draft" ? "{version}" : value }))' > $@
 
 $(BUILD)/%.pdf: $(BUILD)/%.docx
 	unoconv $<

--- a/license.md
+++ b/license.md
@@ -13,7 +13,7 @@ In order to receive this license, you have to agree to its rules.  Those rules a
 
 # Notices
 
-Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the terms of this license or a link to https://roundrobinlicense.com/`version` and a clear, written sign that this license applies to this software.
+Give everyone who gets a copy of any part of this software from you the text of this license or a link to https://roundrobinlicense.com/`version` and tell them in writing that the license applies to the software.
 
 # Copyleft
 

--- a/license.md
+++ b/license.md
@@ -13,7 +13,7 @@ In order to receive this license, you have to agree to its rules.  Those rules a
 
 # Notices
 
-Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the terms of this license or a link to https://roundrobinlicense.com/`version`.
+Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the terms of this license or a link to https://roundrobinlicense.com/`version` and a clear, written sign that this license applies to this software.
 
 # Copyleft
 

--- a/license.md
+++ b/license.md
@@ -13,7 +13,7 @@ In order to receive this license, you have to agree to its rules.  Those rules a
 
 # Notices
 
-Give everyone who gets a copy of any part of this software from you the text of this license or a link to https://roundrobinlicense.com/`version` and tell them in writing that the license applies to the software.
+Give the text of this license or a link to https://roundrobinlicense.com/`version` to everyone who gets a copy of any part of this software from you, along with a note making clear that this license applies to the software.
 
 # Copyleft
 


### PR DESCRIPTION
Since there's no copyright line or other fill-in-the-blank connecting the license to the software, make sure that recipients can tell that the license applies to the software.